### PR TITLE
Add Chrome Web Store installation method doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ This is a Chrome extension that will mask GUIDs (such as Subscription IDs), emai
 
 ## Install the Extension
 
+#### From Chrome Web Store
+
+1. In Chrome goto [Chrome Web Store](https://chrome.google.com/webstore/search/azure%20mask)
+2. Click on Azure Mask extension
+3. Click on Add To Chrome
+4. Confirm any prompts
+
 #### From Package
 
 1. `git clone git@github.com:clarkio/azure-mask.git`


### PR DESCRIPTION
Suggested modification to README.md to include a third option for installation via the Chrome Web Store. I originally installed via the .crx file and was treated to a message later on from Chrome indicating "Extensions disabled by Chrome" and reference to the following page: https://support.google.com/chrome/answer/2811969?visit_id=1-636444545442955362-1145198513&p=ui_remove_non_cws_extensions&rd=1
I found the extension published in the Chrome Web Store, and figured it might be a good first option to present for installation in README.md.