### PR TITLE
Hide sensitive data in QnA maker portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
 # Azure Mask Changelog
 
+## 1.1.8 (2021-04-17)
+### Added
+- Hiding of sensitive data in QnA maker portal (Thanks to @taqabubaker in https://github.com/clarkio/azure-mask/pull/63)
 
 ## 1.1.7 (2021-04-17)
 ### Added
 - Email masking in account/user drop-down menu (Thanks to @
-mhdbouk in #65)
+mhdbouk in https://github.com/clarkio/azure-mask/pull/65)
 
 ## 1.1.6 (2021-04-17)
 ### Added
-- Avatar masking (Thanks to @sinedied in #67)
+- Avatar masking (Thanks to @sinedied in https://github.com/clarkio/azure-mask/pull/67)
 
 ## 1.1.5 (2019-04-22)
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "name": "azure-mask",
-  "version": "1.1.7"
+  "version": "1.1.8"
 }

--- a/src/content-script/mask-process.js
+++ b/src/content-script/mask-process.js
@@ -32,6 +32,15 @@ style.sheet.insertRule(
 style.sheet.insertRule(
   `.${maskEnabledClassName} .fxs-mecontrol-flyout { ${blurCss} }`
 ); // user account menu
+style.sheet.insertRule(
+  `.${maskEnabledClassName} textarea.bg-white { ${blurCss} }`
+); // deployment box in (QnA maker portal)
+style.sheet.insertRule(
+  `.${maskEnabledClassName} span.qna-cs-user-id { display: none }`
+); // hide user id in profile side menu (QnA maker portal)
+style.sheet.insertRule(
+  `.${maskEnabledClassName} div.directory-list-element-id { ${blurCss} }`
+); // profile side menu in (QnA maker portal)
 
 getStoredMaskedStatus(isMasked => {
   isMasked

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,7 +18,8 @@
         "*://*.portal.azure.com/*",
         "*://portal.azure.com/*",
         "*://functions.azure.com/*",
-        "*://portal.azure.gov/*"
+        "*://portal.azure.gov/*",
+        "*://*.qnamaker.ai/*"
       ],
       "js": ["/content-script/mask-process.js"],
       "run_at": "document_idle",
@@ -32,6 +33,7 @@
     "clipboardWrite",
     "*://*.portal.azure.com/*",
     "*://portal.azure.com/*",
-    "*://functions.azure.com/*"
+    "*://functions.azure.com/*",
+    "*://*.qnamaker.ai/*"
   ]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Az Mask",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Does it's best to find and conceal sensitive Azure information found in the portal views",
   "icons": {
     "16": "/icons/icon16.png",


### PR DESCRIPTION
Fixes #60 
This PR to support and hide the sensitive data in QnA maker portal based on issue #60.
List of the hided data:

- **QnA Maker Key in _view code_ popup.**
![image](https://user-images.githubusercontent.com/17325563/91941202-81674380-ed01-11ea-8b2d-e5bd7e5f40ce.png)

- **QnA Maker Key in _deployment details_ section at _Settings_ screen**
![image](https://user-images.githubusercontent.com/17325563/91941345-bffcfe00-ed01-11ea-8d3c-677193c4ea3b.png)

- **Username and subscriptions Ids in _Profile_ side menu**
![image](https://user-images.githubusercontent.com/17325563/91941649-33067480-ed02-11ea-99c6-481b985da37c.png)



