### PR TITLE
Change azure.gov to azure.us

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,7 +18,7 @@
         "*://*.portal.azure.com/*",
         "*://portal.azure.com/*",
         "*://functions.azure.com/*",
-        "*://portal.azure.gov/*",
+        "*://portal.azure.us/*",
         "*://*.qnamaker.ai/*"
       ],
       "js": [


### PR DESCRIPTION
Azure for Government domain is Azure.us , not Azure.gov